### PR TITLE
Fix workflow not running because main branch doesn't exist

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.0]
+        php: [8.1]
         laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,11 @@ name: run-tests
 
 on:
   push:
-    branches: [main]
+    branches:
+      - master
   pull_request:
-    branches: [main]
+    branches:
+      - master
 
 jobs:
   test:

--- a/src/Enums/StatusEnum.php
+++ b/src/Enums/StatusEnum.php
@@ -8,10 +8,10 @@ use Datomatic\EnumHelper\EnumHelper;
  * @method static self DRAFT()
  * @method static self PUBLISHED()
  */
-enum StatusEnum
+enum StatusEnum: string
 {
     use EnumHelper;
 
-    case DRAFT;
-    case PUBLISHED;
+    case DRAFT = 'DRAFT';
+    case PUBLISHED = 'PUBLISHED';
 }


### PR DESCRIPTION
Updated the run-tests.yml workflow to run on push and pull requests open to the `master` branch instead of `main`, since `main` branch does't exist.

Note: This PR only makes sure the Workflow runs, it does not takes in consideration if it passes/fails afterwards